### PR TITLE
Add :Z so postgresql can init the db without selinux denying stuff

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -11,7 +11,7 @@ services:
       - POSTGRES_PASSWORD=redhat-20
       - POSTGRES_DB=coffeeshopdb
     volumes:
-      - ./init-postgresql.sql:/docker-entrypoint-initdb.d/init-postgresql.sql
+      - ./init-postgresql.sql:/docker-entrypoint-initdb.d/init-postgresql.sql:Z
     networks:
       - my-network
 


### PR DESCRIPTION
Without this change I get a selinux denied on rhel 8.5 when running
podman-compose up. Use :Z to avoid this denials and get proper labelling
going. The upper-case :Z is used as this mountpoint does not need to be
shared across multiple containers.

Signed-off-by: Michele Baldessari <michele@acksyn.org>