### PR TITLE
Add Debezium tracingspancontext column to OutboxEvent table.

### DIFF
--- a/init-postgresql.sql
+++ b/init-postgresql.sql
@@ -29,6 +29,7 @@ create table coffeeshop.OutboxEvent (
                              aggregateid varchar(255) not null,
                              type varchar(255) not null,
                              timestamp timestamp not null,
+                             tracingspancontext varchar(255),
                              payload varchar(8000),
                              primary key (id)
 );


### PR DESCRIPTION
Added a required column to the OutboxEvent table. Storing OrderUpdates gives errors without this column in the table.